### PR TITLE
Correct link to GitHub

### DIFF
--- a/tiddlers/GitHub.tid
+++ b/tiddlers/GitHub.tid
@@ -3,6 +3,6 @@ icon: $:/core/images/github
 modified: 20160329003029333
 title: GitHub
 type: text/vnd.tiddlywiki
-url: https://githu.com/sukima/dev-tritarget-org/
+url: https://github.com/sukima/dev-tritarget-org/
 
 The source for this website is available at <a href={{!!url}}>{{!!url}}</a>


### PR DESCRIPTION
Link is missing the letter "b" in GitHub